### PR TITLE
changes the NOT IN to a NOT EXISTS

### DIFF
--- a/migrations/20230113214101_discriminator.sql
+++ b/migrations/20230113214101_discriminator.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION generate_discriminator(TEXT)
+RETURNS SMALLINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    out SMALLINT;
+BEGIN
+    SELECT * FROM (
+        SELECT
+            trunc(random() * 9999 + 1) AS discrim
+        FROM
+            generate_series(1, 9999)
+    ) AS result
+    WHERE NOT EXISTS (
+        SELECT discriminator FROM users WHERE username = $1 AND discriminator = result.discrim
+    )
+    LIMIT 1
+    INTO out;
+    RETURN out;
+END;
+$$;


### PR DESCRIPTION
For discriminator searching, this PR makes the DB use the NOT EXISTS clause instead of NOT IN to make the query slightly more efficient.